### PR TITLE
Add configurable dew point output units

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ To add the integration to your Home Assistant instance, use the button below:
 > [!TIP]
 > You can easily set up multiple dew point sensors for different locations by clicking Add Entry on the Dew Point integration page in Home Assistant. No YAML configuration is required, and each sensor can have its own unique setup.
 
+### Output units
+
+By default, the integration automatically matches the dew point output unit to the temperature sensor input (°C or °F).
+You can override this in the config UI by selecting an explicit output unit.
+
 
 
 ### Manual Configuration

--- a/custom_components/dew_point/config_flow.py
+++ b/custom_components/dew_point/config_flow.py
@@ -11,6 +11,9 @@ from homeassistant.helpers.selector import (
     EntitySelectorConfig,
     NumberSelector,
     NumberSelectorConfig,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
 )
 
 from . import DOMAIN
@@ -20,8 +23,15 @@ _LOGGER = logging.getLogger(__name__)
 CONF_TEMPERATURE_SENSOR = "temperature_sensor"
 CONF_HUMIDITY_SENSOR = "humidity_sensor"
 CONF_DECIMAL_PLACES = "decimal_places"
+CONF_OUTPUT_UNIT = "output_unit"
 
 DEFAULT_NAME = "Dew Point"
+DEFAULT_OUTPUT_UNIT = "auto"
+OUTPUT_UNIT_OPTIONS = [
+    {"label": "Auto", "value": "auto"},
+    {"label": "Celsius (°C)", "value": "celsius"},
+    {"label": "Fahrenheit (°F)", "value": "fahrenheit"},
+]
 
 
 class DewpointConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -43,6 +53,7 @@ class DewpointConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_TEMPERATURE_SENSOR: user_input[CONF_TEMPERATURE_SENSOR],
                     CONF_HUMIDITY_SENSOR: user_input[CONF_HUMIDITY_SENSOR],
                     CONF_DECIMAL_PLACES: decimal_places,
+                    CONF_OUTPUT_UNIT: user_input[CONF_OUTPUT_UNIT],
                 },
             )
 
@@ -62,6 +73,12 @@ class DewpointConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         step=1,  # Only integers
                         mode="box",
                         unit_of_measurement="decimals"
+                    )
+                ),
+                vol.Required(CONF_OUTPUT_UNIT, default=DEFAULT_OUTPUT_UNIT): SelectSelector(
+                    SelectSelectorConfig(
+                        options=OUTPUT_UNIT_OPTIONS,
+                        mode=SelectSelectorMode.DROPDOWN,
                     )
                 ),
             }
@@ -92,6 +109,7 @@ class DewpointOptionsFlowHandler(OptionsFlowWithConfigEntry):
                     CONF_TEMPERATURE_SENSOR: user_input[CONF_TEMPERATURE_SENSOR],
                     CONF_HUMIDITY_SENSOR: user_input[CONF_HUMIDITY_SENSOR],
                     CONF_DECIMAL_PLACES: decimal_places,
+                    CONF_OUTPUT_UNIT: user_input[CONF_OUTPUT_UNIT],
                 },
             )
 
@@ -107,6 +125,9 @@ class DewpointOptionsFlowHandler(OptionsFlowWithConfigEntry):
         )
         decimal_places = options.get(
             CONF_DECIMAL_PLACES, data.get(CONF_DECIMAL_PLACES, 1)
+        )
+        output_unit = options.get(
+            CONF_OUTPUT_UNIT, data.get(CONF_OUTPUT_UNIT, DEFAULT_OUTPUT_UNIT)
         )
 
         schema = vol.Schema(
@@ -124,6 +145,12 @@ class DewpointOptionsFlowHandler(OptionsFlowWithConfigEntry):
                         step=1,
                         mode="box",
                         unit_of_measurement="decimals"
+                    )
+                ),
+                vol.Required(CONF_OUTPUT_UNIT, default=output_unit): SelectSelector(
+                    SelectSelectorConfig(
+                        options=OUTPUT_UNIT_OPTIONS,
+                        mode=SelectSelectorMode.DROPDOWN,
                     )
                 ),
             }


### PR DESCRIPTION
### Motivation

- Provide users control over the unit used to report the calculated dew point (match sensor input automatically or force `°C`/`°F`).

### Description

- Add an `output_unit` option to the integration `config_flow` and options flow using a `SelectSelector` with values `auto`, `celsius`, and `fahrenheit` and default `auto`.
- Introduce `output_unit` handling in the sensor setup and pass the selected option into `DewPointSensor` via its constructor.
- Compute dew point in Celsius with `_calculate_dew_point_arden_buck`, then resolve and convert to the requested output unit using a new helper `_resolve_output_unit`, and set the sensor's native unit/value accordingly.
- Expand `DewPointSensor` attributes to expose the input `temperature` value, its `temperature_unit`, and the effective `output_unit`, and improve `_get_dry_temp` to return `(temp_c, native_value, native_unit)`.
- Document the new output unit behavior in `README.md`.

### Testing

- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819e821e8c8322b5154e96ebf7ada5)