### PR TITLE
Expose temperature and humidity entities

### DIFF
--- a/custom_components/dew_point/sensor.py
+++ b/custom_components/dew_point/sensor.py
@@ -162,11 +162,13 @@ class DewPointSensor(SensorEntity):
         return {
             "temperature": self._dry_temp_value,
             "temperature_unit": self._dry_temp_unit,
+            "temperature_entity_id": self._entity_dry_temp,
             "humidity": (
                 round(self._rel_hum_value * 100, 1) 
                 if self._rel_hum_value is not None 
                 else None
             ),
+            "humidity_entity_id": self._entity_rel_hum,
             "decimal_places": self._decimal_places,
             "output_unit": self._attr_native_unit_of_measurement,
         }


### PR DESCRIPTION
This change exposes the temperature and humidity entity identifiers  configured in a dew point entity. They appear as extra state attributes and can be referenced many ways, including in template expressions.

The motivating use case for this change is to reduce markdown card configuration complexity. The following markdown card uses a prototype of this change. Each of the 21 numbers on this card links to a corresponding history graph. Such a card is possible without this change, but seems to need the sensors be configured both in the card and in the dew point entity.
<img width="330" height="346" alt="image" src="https://github.com/user-attachments/assets/a52bec74-e8d3-4616-9796-2caf85995625" />
The following configuration produces this card:
```yaml
type: markdown
content: >
  {% set sensors = [
    "sensor.back_woods_dew_point",
    "sensor.crawl_space_dew_point",
    "sensor.garage_dew_point",
    "sensor.computer_room_dew_point",
    "sensor.main_bedroom_dew_point",
    "sensor.center_hall_dew_point",
    "sensor.bonus_room_dew_point",
  ] %}
  {% set startHist = (now() - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0).isoformat() %}

  {% macro stateDsp(entityId) -%}
    {% set qryParms = {"entity_id": entityId,
                       "start_date": startHist,
                       "back" : 1} -%}
    [{{ states(entityId, with_unit=true) }}](/history?{{ qryParms | urlencode }})
  {%- endmacro %}

  | Area | Temp. | Dew pt. | Hum. |
  | :--- | ----: | ------: | ---: |
  {%- for dpId in sensors %}
    | {{ area_name(dpId) }} | {{
    stateDsp(state_attr(dpId, 'temperature_entity_id')) }} | {{
    stateDsp(dpId) }} | {{
    stateDsp(state_attr(dpId, 'humidity_entity_id')) }} |
  {%- endfor %}
title: Temperature + humidity
card_mod:
  style:
    ha-markdown$: |
      a {
        text-decoration: none;
        color: inherit !important;
      }
```
Note: This configuration also uses card-mod from Home Assistant Community Store.