### PR TITLE
chore: Tune Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Tune Dependabot automation so routine version updates create less noise while security updates and high-value dependency maintenance remain automated.

## Changes

- Disable routine npm version update PRs where npm is only used for release tooling.
- Group useful npm, Python, and GitHub Actions updates to reduce PR volume.
- Keep weekly or monthly schedules where dependency updates still support active build, release, or documentation workflows.

## Validation

- Parsed all updated Dependabot YAML files successfully.
- Ran `git diff --check` for the changed Dependabot files.
