### PR TITLE
fix: Publish Dew Point beta releases automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,14 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [beta, main]
+    paths:
+      - ".github/workflows/release.yml"
+      - "custom_components/**"
+      - "hacs.json"
+      - "package-lock.json"
+      - "package.json"
+      - "release.config.cjs"
 
 permissions:
   contents: write

--- a/.github/workflows/sync-after-pre-release.yml
+++ b/.github/workflows/sync-after-pre-release.yml
@@ -1,0 +1,14 @@
+name: Sync beta back to dev
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: ${{ github.event.release.prerelease == true && github.event.release.target_commitish == 'beta' }}
+    uses: nicxe/.github/.github/workflows/reusable-sync-beta-to-dev.yml@main
+    secrets: inherit

--- a/.github/workflows/sync-after-release.yml
+++ b/.github/workflows/sync-after-release.yml
@@ -1,0 +1,14 @@
+name: Sync main back to beta
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-beta:
+    if: ${{ github.event.release.prerelease == false && github.event.release.target_commitish == 'main' }}
+    uses: nicxe/.github/.github/workflows/resusable-sync-main-back-to-beta.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What changed

Dew Point now runs semantic-release for pushes to `beta` as well as `main`, matching the F1 Sensor release flow. The workflow only runs for release-relevant files.

## Why

The shared semantic-release configuration already defines `beta` as the prerelease channel, but the repository workflow only ran on `main`, so beta pushes could not publish prereleases.

## Validation

Validated all GitHub Actions workflow YAML files and checked the branch diff for whitespace errors.