### PR TITLE
fix: Enable complete Dew Point release synchronization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,14 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [beta, main]
+    paths:
+      - ".github/workflows/release.yml"
+      - "custom_components/**"
+      - "hacs.json"
+      - "package-lock.json"
+      - "package.json"
+      - "release.config.cjs"
 
 permissions:
   contents: write

--- a/.github/workflows/sync-after-pre-release.yml
+++ b/.github/workflows/sync-after-pre-release.yml
@@ -1,0 +1,14 @@
+name: Sync beta back to dev
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: ${{ github.event.release.prerelease == true && github.event.release.target_commitish == 'beta' }}
+    uses: nicxe/.github/.github/workflows/reusable-sync-beta-to-dev.yml@main
+    secrets: inherit

--- a/.github/workflows/sync-after-release.yml
+++ b/.github/workflows/sync-after-release.yml
@@ -1,0 +1,14 @@
+name: Sync main back to beta
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-beta:
+    if: ${{ github.event.release.prerelease == false && github.event.release.target_commitish == 'main' }}
+    uses: nicxe/.github/.github/workflows/resusable-sync-main-back-to-beta.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What changed

Adds the same beta release trigger and release synchronization workflows to the default branch. GitHub loads release-event workflows from the default branch, so this makes beta-to-dev and main-to-beta synchronization available for future releases.

## Validation

All workflow YAML files parse successfully, and the beta release workflow has already completed successfully and created `v0.9.0-beta.1`.