### PR TITLE
fix: **Prevent recurring Dew Point Repairs for unavailable sources**

### DIFF
--- a/custom_components/dew_point/repairs.py
+++ b/custom_components/dew_point/repairs.py
@@ -54,7 +54,7 @@ _TEMPERATURE_SOURCE_KEYS = {
 
 
 class SourceIssueType(StrEnum):
-    """Persistent, user-actionable source failures."""
+    """Source failures, including legacy issue types retained for cleanup."""
 
     MISSING = "missing"
     INCOMPATIBLE = "incompatible"
@@ -90,17 +90,12 @@ def async_update_source_issue(
     *,
     entity_id: str | None = None,
 ) -> None:
-    """Create or clear a persistent source issue.
-
-    ``UNAVAILABLE`` must only be passed after the source has remained unavailable
-    beyond the runtime grace period, so normal startup ordering does not create
-    transient issues.
-    """
+    """Create or clear a persistent source issue."""
     if source_key not in _SOURCE_KINDS:
         raise ValueError(f"Unsupported source key: {source_key}")
 
     async_clear_source_issues(hass, entry.entry_id, source_key)
-    if issue_type is None:
+    if issue_type in (None, SourceIssueType.UNAVAILABLE):
         return
 
     source_kind = _SOURCE_KINDS[source_key]

--- a/custom_components/dew_point/runtime.py
+++ b/custom_components/dew_point/runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 from enum import StrEnum
 import logging
 import math
@@ -33,7 +32,7 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.event import async_call_later, async_track_state_change_event
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .calculation import MoistAirProperties, calculate_moist_air_properties
@@ -59,7 +58,6 @@ from .const import (
 from .repairs import SourceIssueType, async_update_source_issue
 
 _LOGGER = logging.getLogger(__name__)
-_UNAVAILABLE_REPAIR_DELAY = timedelta(minutes=5)
 
 type RuntimeListener = Callable[[], None]
 
@@ -142,7 +140,6 @@ class DewPointRuntime:
         self.source_statuses: dict[str, SourceStatus] = {}
         self._listeners: set[RuntimeListener] = set()
         self._unsub_state_listener: Callable[[], None] | None = None
-        self._unavailable_issue_unsubs: dict[str, Callable[[], None]] = {}
         self._active_issues: dict[str, SourceIssueType | None] = {}
         self._logged_problem_signature: tuple[tuple[str, SourceStatus], ...] = ()
 
@@ -165,9 +162,6 @@ class DewPointRuntime:
         if self._unsub_state_listener is not None:
             self._unsub_state_listener()
             self._unsub_state_listener = None
-        for cancel_unavailable_issue in self._unavailable_issue_unsubs.values():
-            cancel_unavailable_issue()
-        self._unavailable_issue_unsubs.clear()
         self._listeners.clear()
 
     @property
@@ -432,11 +426,6 @@ class DewPointRuntime:
         }
         for source_key, reading in readings.items():
             entity_id = source_ids[source_key]
-            if reading.status is SourceStatus.UNAVAILABLE:
-                self._schedule_unavailable_issue(source_key, entity_id)
-                continue
-
-            self._cancel_unavailable_issue(source_key)
             issue_type = {
                 SourceStatus.MISSING: SourceIssueType.MISSING,
                 SourceStatus.INCOMPATIBLE: SourceIssueType.INCOMPATIBLE,
@@ -454,63 +443,6 @@ class DewPointRuntime:
                 entity_id=entity_id,
             )
             self._active_issues[source_key] = issue_type
-
-    @callback
-    def _schedule_unavailable_issue(
-        self, source_key: str, entity_id: str | None
-    ) -> None:
-        """Create a repair only when a source stays unavailable."""
-        if (
-            source_key in self._unavailable_issue_unsubs
-            or self._active_issues.get(source_key) is SourceIssueType.UNAVAILABLE
-        ):
-            return
-
-        if (
-            source_key in self._active_issues
-            and self._active_issues[source_key] is not None
-        ):
-            async_update_source_issue(
-                self.hass,
-                self.entry,
-                source_key,
-                None,
-                entity_id=entity_id,
-            )
-        self._active_issues[source_key] = None
-
-        @callback
-        def async_create_unavailable_issue(_now: datetime) -> None:
-            self._unavailable_issue_unsubs.pop(source_key, None)
-            if self.source_statuses.get(source_key) is not SourceStatus.UNAVAILABLE:
-                return
-            async_update_source_issue(
-                self.hass,
-                self.entry,
-                source_key,
-                SourceIssueType.UNAVAILABLE,
-                entity_id=entity_id,
-            )
-            self._active_issues[source_key] = SourceIssueType.UNAVAILABLE
-            _LOGGER.warning(
-                "Source has remained unavailable for %s: %s",
-                self.entry.title,
-                source_key,
-            )
-
-        self._unavailable_issue_unsubs[source_key] = async_call_later(
-            self.hass,
-            _UNAVAILABLE_REPAIR_DELAY,
-            async_create_unavailable_issue,
-        )
-
-    @callback
-    def _cancel_unavailable_issue(self, source_key: str) -> None:
-        """Cancel a pending unavailable-source repair."""
-        if cancel_unavailable_issue := self._unavailable_issue_unsubs.pop(
-            source_key, None
-        ):
-            cancel_unavailable_issue()
 
     def _log_status_transition(self, statuses: dict[str, SourceStatus]) -> None:
         """Log source problems once and recovery once."""

--- a/custom_components/dew_point/tests/test_issue_58.py
+++ b/custom_components/dew_point/tests/test_issue_58.py
@@ -1,0 +1,200 @@
+"""Regression tests for issue 58."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
+    PERCENTAGE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+
+from custom_components.dew_point import DOMAIN, repairs
+from custom_components.dew_point.const import (
+    CONF_CONDENSATION_THRESHOLD,
+    CONF_HUMIDITY_SENSOR,
+    CONF_HYSTERESIS,
+    CONF_SOURCE_TYPE,
+    CONF_TEMPERATURE_SENSOR,
+    DEFAULT_CONDENSATION_THRESHOLD,
+    DEFAULT_HYSTERESIS,
+    SOURCE_TYPE_SENSORS,
+)
+from custom_components.dew_point.runtime import DewPointRuntime, SourceStatus
+
+
+def _entry() -> MockConfigEntry:
+    """Return a configured sensor-based helper."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Bedroom",
+        options={
+            CONF_NAME: "Bedroom",
+            CONF_SOURCE_TYPE: SOURCE_TYPE_SENSORS,
+            CONF_TEMPERATURE_SENSOR: "sensor.bedroom_temperature",
+            CONF_HUMIDITY_SENSOR: "sensor.bedroom_humidity",
+            CONF_CONDENSATION_THRESHOLD: DEFAULT_CONDENSATION_THRESHOLD,
+            CONF_HYSTERESIS: DEFAULT_HYSTERESIS,
+        },
+    )
+
+
+def _set_sensor_states(hass, state: str) -> None:
+    """Set both configured source sensors to one state."""
+    hass.states.async_set(
+        "sensor.bedroom_temperature",
+        state,
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+        },
+    )
+    hass.states.async_set(
+        "sensor.bedroom_humidity",
+        state,
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
+            ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
+        },
+    )
+
+
+def _unavailable_issue(hass, entry: MockConfigEntry, source_key: str):
+    """Return the legacy unavailable Repair for a source, if present."""
+    return ir.async_get(hass).async_get_issue(
+        DOMAIN,
+        repairs.source_issue_id(
+            entry.entry_id,
+            source_key,
+            repairs.SourceIssueType.UNAVAILABLE,
+        ),
+    )
+
+
+@pytest.mark.parametrize("state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+async def test_unavailable_sources_do_not_create_repairs(hass, state: str) -> None:
+    """Unavailable and unknown sources stay quiet and recover automatically."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+    _set_sensor_states(hass, state)
+    runtime = DewPointRuntime(hass, entry)
+
+    runtime.async_start()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=6))
+    await hass.async_block_till_done()
+
+    assert runtime.data.available is False
+    assert runtime.source_statuses == {
+        CONF_TEMPERATURE_SENSOR: SourceStatus.UNAVAILABLE,
+        CONF_HUMIDITY_SENSOR: SourceStatus.UNAVAILABLE,
+    }
+    assert _unavailable_issue(hass, entry, CONF_TEMPERATURE_SENSOR) is None
+    assert _unavailable_issue(hass, entry, CONF_HUMIDITY_SENSOR) is None
+
+    hass.states.async_set(
+        "sensor.bedroom_temperature",
+        "20",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+        },
+    )
+    hass.states.async_set(
+        "sensor.bedroom_humidity",
+        "50",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
+            ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.data.available is True
+    runtime.async_stop()
+
+
+async def test_existing_unavailable_repairs_are_cleared(hass) -> None:
+    """Runtime startup removes unavailable Repairs created by older releases."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+    _set_sensor_states(hass, STATE_UNAVAILABLE)
+    issue_id = repairs.source_issue_id(
+        entry.entry_id,
+        CONF_TEMPERATURE_SENSOR,
+        repairs.SourceIssueType.UNAVAILABLE,
+    )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=True,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="temperature_source_unavailable",
+        translation_placeholders={
+            "entity_id": "sensor.bedroom_temperature",
+            "helper_name": "Bedroom",
+        },
+    )
+    assert _unavailable_issue(hass, entry, CONF_TEMPERATURE_SENSOR) is not None
+
+    runtime = DewPointRuntime(hass, entry)
+    runtime.async_start()
+
+    assert _unavailable_issue(hass, entry, CONF_TEMPERATURE_SENSOR) is None
+    runtime.async_stop()
+
+
+async def test_actionable_source_failures_still_create_repairs(hass) -> None:
+    """Missing and incompatible sources remain actionable Repairs."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+    hass.states.async_set(
+        "sensor.bedroom_temperature",
+        "100",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.POWER,
+            ATTR_UNIT_OF_MEASUREMENT: "W",
+        },
+    )
+    runtime = DewPointRuntime(hass, entry)
+
+    runtime.async_start()
+
+    registry = ir.async_get(hass)
+    assert (
+        registry.async_get_issue(
+            DOMAIN,
+            repairs.source_issue_id(
+                entry.entry_id,
+                CONF_TEMPERATURE_SENSOR,
+                repairs.SourceIssueType.INCOMPATIBLE,
+            ),
+        )
+        is not None
+    )
+    assert (
+        registry.async_get_issue(
+            DOMAIN,
+            repairs.source_issue_id(
+                entry.entry_id,
+                CONF_HUMIDITY_SENSOR,
+                repairs.SourceIssueType.MISSING,
+            ),
+        )
+        is not None
+    )
+    runtime.async_stop()


### PR DESCRIPTION
The Dew Point integration no longer creates persistent Repair notifications for source sensors that are temporarily unavailable, intentionally off, or unknown. Affected helpers remain unavailable and recover automatically when their sources return, while missing and incompatible sources continue to produce actionable Repairs. Existing unavailable-source Repairs are cleared automatically. Fixes #58.