### PR TITLE
fix: **Restore Dew Point compatibility with newer Home Assistant rele…

### DIFF
--- a/custom_components/dew_point/__init__.py
+++ b/custom_components/dew_point/__init__.py
@@ -70,7 +70,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.async_on_unload(
             async_handle_source_entity_changes(
                 hass,
-                add_helper_config_entry_to_device=False,
                 helper_config_entry_id=entry.entry_id,
                 set_source_entity_id_or_uuid=_source_entity_updater(
                     hass, entry, tuple(source_keys)

--- a/custom_components/dew_point/sensor.py
+++ b/custom_components/dew_point/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONCENTRATION_GRAMS_PER_CUBIC_METER,
     UnitOfPressure,
     UnitOfTemperature,
 )
@@ -26,6 +25,15 @@ from .const import (
     OUTPUT_UNIT_FAHRENHEIT,
 )
 from .runtime import DewPointRuntime, DewPointRuntimeData
+
+try:
+    from homeassistant.const import UnitOfDensity
+except ImportError:  # Home Assistant < 2026.8
+    from homeassistant.const import (
+        CONCENTRATION_GRAMS_PER_CUBIC_METER as GRAMS_PER_CUBIC_METER,
+    )
+else:
+    GRAMS_PER_CUBIC_METER = UnitOfDensity.GRAMS_PER_CUBIC_METER
 
 ATTR_TEMPERATURE = "temperature"
 ATTR_TEMPERATURE_UNIT = "temperature_unit"
@@ -75,7 +83,7 @@ SENSOR_DESCRIPTIONS: tuple[DewPointSensorEntityDescription, ...] = (
         key="absolute_humidity",
         translation_key="absolute_humidity",
         icon="mdi:water-percent",
-        native_unit_of_measurement=CONCENTRATION_GRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=GRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.ABSOLUTE_HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,

--- a/custom_components/dew_point/tests/test_issue_62.py
+++ b/custom_components/dew_point/tests/test_issue_62.py
@@ -1,0 +1,92 @@
+"""Regression tests for issue 62."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import const as ha_const
+from homeassistant.const import CONF_NAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import dew_point
+from custom_components.dew_point import sensor
+from custom_components.dew_point.const import (
+    CONF_CONDENSATION_THRESHOLD,
+    CONF_HUMIDITY_SENSOR,
+    CONF_HYSTERESIS,
+    CONF_SOURCE_TYPE,
+    CONF_TEMPERATURE_SENSOR,
+    DEFAULT_CONDENSATION_THRESHOLD,
+    DEFAULT_HYSTERESIS,
+    SOURCE_TYPE_SENSORS,
+)
+
+
+def _entry() -> MockConfigEntry:
+    """Return a configured sensor-based helper."""
+    return MockConfigEntry(
+        domain=dew_point.DOMAIN,
+        title="Bedroom",
+        options={
+            CONF_NAME: "Bedroom",
+            CONF_SOURCE_TYPE: SOURCE_TYPE_SENSORS,
+            CONF_TEMPERATURE_SENSOR: "sensor.bedroom_temperature",
+            CONF_HUMIDITY_SENSOR: "sensor.bedroom_humidity",
+            CONF_CONDENSATION_THRESHOLD: DEFAULT_CONDENSATION_THRESHOLD,
+            CONF_HYSTERESIS: DEFAULT_HYSTERESIS,
+        },
+    )
+
+
+async def test_setup_uses_supported_source_change_api(hass) -> None:
+    """Setup must not pass the source change argument removed in HA 2027.8."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    def async_handle_source_entity_changes(
+        _hass,
+        *,
+        helper_config_entry_id: str,
+        set_source_entity_id_or_uuid: Callable[[str], None],
+        source_device_id: str | None,
+        source_entity_id_or_uuid: str,
+        source_entity_removed: Callable[[], Coroutine[Any, Any, None]] | None = None,
+    ) -> Callable[[], None]:
+        """Model the Home Assistant 2027.8 source change API."""
+        return lambda: None
+
+    with (
+        patch(
+            "custom_components.dew_point.async_handle_source_entity_changes",
+            side_effect=async_handle_source_entity_changes,
+        ) as source_change_handler,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(),
+        ),
+    ):
+        assert await dew_point.async_setup_entry(hass, entry) is True
+
+    assert source_change_handler.call_count == 2
+    entry.runtime_data.async_stop()
+
+
+def test_absolute_humidity_uses_supported_density_unit() -> None:
+    """The sensor module must not import the density constant removed in HA 2027.8."""
+    description = next(
+        description
+        for description in sensor.SENSOR_DESCRIPTIONS
+        if description.key == "absolute_humidity"
+    )
+
+    assert not hasattr(sensor, "CONCENTRATION_GRAMS_PER_CUBIC_METER")
+    if unit_of_density := getattr(ha_const, "UnitOfDensity", None):
+        assert (
+            description.native_unit_of_measurement
+            == unit_of_density.GRAMS_PER_CUBIC_METER
+        )
+    else:
+        assert description.native_unit_of_measurement == "g/m³"


### PR DESCRIPTION
…ases**

The Dew Point integration no longer produces compatibility warnings when starting on current Home Assistant releases. Existing configurations continue working without user action and remain compatible with upcoming Home Assistant changes. Fixes #62.